### PR TITLE
Handle `/put` in the da server

### DIFF
--- a/celestia_server.go
+++ b/celestia_server.go
@@ -43,6 +43,7 @@ func (d *CelestiaServer) Start() error {
 
 	mux.HandleFunc("/get/", d.HandleGet)
 	mux.HandleFunc("/put/", d.HandlePut)
+	mux.HandleFunc("/put", d.HandlePut)
 
 	d.httpServer.Handler = mux
 


### PR DESCRIPTION
A recent update makes op stack use `/put` for the DA server as defined in the spec, this should add support for both `/put` and `/put/`